### PR TITLE
Add logic to apply custom app name throughout the repo

### DIFF
--- a/bin/camelize
+++ b/bin/camelize
@@ -1,0 +1,27 @@
+#!/usr/bin/env elixir
+
+defmodule PBCamelizer do
+  @moduledoc """
+  This converts the given string to camel case. The implementation was lifted
+  from: https://github.com/nurugger07/inflex - to avoid having a dependency here
+  """
+  def camelize(word, option\\:upper) do
+    case Regex.split(~r/(?:^|[-_])|(?=[A-Z])/, to_string(word)) do
+      words -> words |> camelize_list(option)
+                    |> Enum.join
+    end
+  end
+
+  defp camelize_list([], :upper), do: []
+  defp camelize_list([h|tail], :lower) do
+    [lowercase(h)] ++ camelize_list(tail, :upper)
+  end
+  defp camelize_list([h|tail], :upper) do
+    [capitalize(h)] ++ camelize_list(tail, :upper)
+  end
+
+  def capitalize(word), do: String.capitalize(word)
+  def lowercase(word), do: String.downcase(word)
+end
+
+IO.puts PBCamelizer.camelize(List.first(System.argv))

--- a/bin/setup
+++ b/bin/setup
@@ -19,6 +19,21 @@ command -v npm >/dev/null 2>&1 || {
   exit 1
 }
 
+# Rename PhoenixBase throughout the codebase
+echo "What is the name of your app? [MyApp] "
+read new_name
+if [[ -z $new_name ]]; then
+  new_name="MyApp"
+fi
+camel_case_name=`./bin/camelize $new_name`
+underscore_name=`./bin/underscore $new_name`
+export LC_ALL=C
+sed -i '' -e "s/PhoenixBase/$camel_case_name/" `find . -name '*.ex*'`
+sed -i '' -e "s/%PhoenixBase/$camel_case_name/" `find . -name '*.ex*'`
+sed -i '' -e "s/phoenix_base/$underscore_name/" `find . -name '*.ex*'`
+mv lib/phoenix_base lib/$underscore_name
+mv lib/phoenix_base.ex lib/$underscore_name.ex
+
 echo "----------------------------------------------------------"
 echo "Ensuring Hex is installed..."
 echo "----------------------------------------------------------"
@@ -50,4 +65,13 @@ echo "----------------------------------------------------------"
 echo "Setup complete!"
 echo "----------------------------------------------------------"
 
+echo "If you cloned PhoenixBase from Github, you may want to reinitialize git:"
+echo "    rm -rf .git/"
+echo ""
+echo "You might also want to rename this directory to your app name:"
+echo "    cd .."
+echo "    mv phoenix_base $underscore_name"
+echo ""
 echo "Run the web server with mix phoenix.server, and view localhost:4000"
+echo ""
+

--- a/bin/underscore
+++ b/bin/underscore
@@ -1,0 +1,17 @@
+#!/usr/bin/env elixir
+
+defmodule PBUnderscorer do
+  @moduledoc """
+  This converts the given string to underscore. The implementation was lifted
+  from: https://github.com/nurugger07/inflex - to avoid having a dependency here
+  """
+  def underscore(word) when is_binary(word) do
+    word
+    |> String.replace(~r/([A-Z]+)([A-Z][a-z])/, "\\1_\\2")
+    |> String.replace(~r/([a-z\d])([A-Z])/, "\\1_\\2")
+    |> String.replace(~r/-/, "_")
+    |> String.downcase
+  end
+end
+
+IO.puts PBUnderscorer.underscore(List.first(System.argv))


### PR DESCRIPTION
When setting up a new app using this as a base, it's a little tedious to change every instance of `PhoenixBase` and `:phoenix_base` throughout the codebase to the new app name. This PR adds a step to `bin/setup` that prompts the user for the app name they'd like to use, then renames files and replaces strings in the repo as needed.

This feature uses sed for the string replacement. It should work on Mac and Unix systems, but probably not Windows. Ideally, we would have a pure Elixir solution, but this will get the ball rolling.
