### PR TITLE
Install Swoosh for Email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ erl_crash.dump
 # Alternatively, you may comment the line below and commit the
 # secrets file as long as you replace its contents by environment
 # variables.
-/config/prod.secret.exs
+# /config/prod.secret.exs

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Ready to run in production? Please [check our deployment guides](http://www.phoe
 - **Webpack** for assets
 - **Ecto 2.0** for database
 - **Hound** for integration tests
+- **Swoosh** for email
 
 ## Continuous Integration
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -42,3 +42,7 @@ config :phoenix_base, PhoenixBase.Repo,
   database: "phoenix_base_dev",
   hostname: "localhost",
   pool_size: 10
+
+# Configure mailer for local previews
+config :phoenix_base, PhoenixBase.Mailer,
+  adapter: Swoosh.Adapters.Local

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -1,0 +1,22 @@
+use Mix.Config
+
+# Configure endpoint with secret key
+config :phoenix_base, PhoenixBase.Endpoint,
+  secret_key_base: System.get_env("SECRET_KEY_BASE")
+
+# Configure your database
+config :phoenix_base, PhoenixBase.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  url: System.get_env("DATABASE_URL"),
+  pool_size: 20
+
+# Default SMTP adapter, use the appropriate adapter
+# for your project. All adapters are listed here:
+#
+# https://hexdocs.pm/swoosh/Swoosh.Mailer.html
+config :phoenix_base, Phoenix.Mailer,
+  adapter: Swoosh.Adapters.SMTP,
+  relay: "smtp.example.com",
+  username: {:system, "SMTP_USERNAME"},
+  password: {:system, "SMTP_PASSWORD"},
+  tls: :always

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,3 +23,7 @@ config :phoenix_base, PhoenixBase.Repo,
 
 # Use PhantomJS for integration tests
 config :hound, driver: "phantomjs"
+
+# Configure mailer for test mode
+config :phoenix_base, PhoenixBase.Mailer,
+  adapter: Swoosh.Adapters.Test

--- a/lib/phoenix_base/mailer.ex
+++ b/lib/phoenix_base/mailer.ex
@@ -1,0 +1,12 @@
+defmodule PhoenixBase.Mailer do
+  @moduledoc """
+  Handles delivering emails through a configured email adapter.
+
+  ## Example
+
+      PhoenixBase.SampleEmail.sample
+      |> Mailer.deliver
+  """
+
+  use Swoosh.Mailer, otp_app: :phoenix_base
+end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule PhoenixBase.Mixfile do
   def application do
     [mod: {PhoenixBase, []},
      applications: [:phoenix, :phoenix_html, :cowboy, :logger, :gettext,
-                    :phoenix_ecto, :postgrex]]
+                    :phoenix_ecto, :postgrex, :swoosh]]
   end
 
   # Specifies which paths to compile per environment.
@@ -39,6 +39,7 @@ defmodule PhoenixBase.Mixfile do
      {:gettext, "~> 0.9"},
      {:cowboy, "~> 1.0"},
      {:earmark, ">= 0.0.0"},
+     {:phoenix_swoosh, "~> 0.1"},
      {:hound, "~> 1.0", only: [:dev, :test]},
      {:ex_doc, ">= 0.0.0", only: [:dev, :test]},
      {:dogma, ">= 0.0.0", only: [:dev, :test]}]

--- a/mix.lock
+++ b/mix.lock
@@ -9,6 +9,7 @@
   "ecto": {:hex, :ecto, "2.0.0-rc.3"},
   "ex_doc": {:hex, :ex_doc, "0.11.4"},
   "fs": {:hex, :fs, "0.9.2"},
+  "gen_smtp": {:hex, :gen_smtp, "0.9.0"},
   "gettext": {:hex, :gettext, "0.11.0"},
   "hackney": {:hex, :hackney, "1.6.0"},
   "hound": {:hex, :hound, "1.0.0"},
@@ -21,10 +22,12 @@
   "phoenix_html": {:hex, :phoenix_html, "2.5.1"},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.3"},
   "phoenix_slime": {:hex, :phoenix_slime, "0.5.1"},
+  "phoenix_swoosh": {:hex, :phoenix_swoosh, "0.1.1"},
   "plug": {:hex, :plug, "1.1.4"},
   "poison": {:hex, :poison, "2.1.0"},
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "postgrex": {:hex, :postgrex, "0.11.1"},
   "ranch": {:hex, :ranch, "1.2.1"},
   "slime": {:hex, :slime, "0.11.0"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0"},
+  "swoosh": {:hex, :swoosh, "0.3.0"}}

--- a/web/emails/sample_email.ex
+++ b/web/emails/sample_email.ex
@@ -1,0 +1,25 @@
+defmodule PhoenixBase.SampleEmail do
+  @moduledoc """
+  A sample email module to demonstrate how to use Swoosh.
+
+  ## Example
+
+  In your controller, you can deliver emails like so:
+
+      PhoenixBase.Mailer.deliver PhoenixBase.SampleEmail.sample
+
+  You can view emails in your browser that have been sent at `/dev/mailbox`.
+  """
+
+  use Phoenix.Swoosh,
+    view: PhoenixBase.EmailView,
+    layout: {PhoenixBase.LayoutView, :email}
+
+  def sample do
+    %Swoosh.Email{}
+    |> from("noreply@example.com")
+    |> to("test@example.com")
+    |> subject("Test Email")
+    |> render_body("sample.html", %{variable: "value"})
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -25,6 +25,14 @@ defmodule PhoenixBase.Router do
     get "/", PageController, :index
   end
 
+  if Mix.env == :dev do
+    scope "/dev" do
+      pipe_through [:browser]
+
+      forward "/mailbox", Plug.Swoosh.MailboxPreview, [base_path: "/dev/mailbox"]
+    end
+  end
+
   # Other scopes may use custom stacks.
   # scope "/api", PhoenixBase do
   #   pipe_through :api

--- a/web/templates/email/sample.html.slim
+++ b/web/templates/email/sample.html.slim
@@ -1,0 +1,1 @@
+<p>Hello, <%= @variable %></p>

--- a/web/templates/layout/email.html.slim
+++ b/web/templates/layout/email.html.slim
@@ -1,0 +1,1 @@
+= render @view_module, @view_template, assigns

--- a/web/views/email_view.ex
+++ b/web/views/email_view.ex
@@ -1,0 +1,7 @@
+defmodule PhoenixBase.EmailView do
+  @moduledoc """
+  Renders all templates for emails.
+  """
+
+  use PhoenixBase.Web, :view
+end


### PR DESCRIPTION
[Swoosh](https://github.com/swoosh/swoosh) is a great email library for Elixir. Since pretty much all our web apps need email, I figure this should be part of Phoenix base.

It comes with a built in preview utility:

![localhost_4000_dev_mailbox_890da85651d70022d36e2690ea8ebe69_and_slack_and_dash](https://cloud.githubusercontent.com/assets/1186992/14830388/493c1f22-0ba5-11e6-80a3-9baed52a2c9d.png)
