### PR TITLE
Fixed bin/rename_project

### DIFF
--- a/bin/rename_project
+++ b/bin/rename_project
@@ -3,9 +3,10 @@
 #
 # $ bin/rename_project PhoenixBase phoenix_base CoolProject cool_project
 
-sed -i '' -e "s/$1/$3/" `find . ! -path "./deps/*" -name "*.ex*"`
-sed -i '' -e "s/%$1/$3/" `find . ! -path "./deps/*" -name "*.ex*"`
-sed -i '' -e "s/$2/$4/" `find . ! -path "./deps/*" -name "*.ex*"`
+find . ! -path "./deps/*" -name "*.ex*" -print0 | xargs -0 sed -i -e "s/$1/$3/g"
+find . ! -path "./deps/*" -name "*.ex*" -print0 | xargs -0 sed -i -e "s/%$1/$3/g"
+find . ! -path "./deps/*" -name "*.ex*" -print0 | xargs -0 sed -i -e "s/$2/$4/g"
+
 mv lib/$2.ex lib/$4.ex
 mv lib/$2 lib/$4
 

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -14,7 +14,7 @@ config :phoenix_base, PhoenixBase.Repo,
 # for your project. All adapters are listed here:
 #
 # https://hexdocs.pm/swoosh/Swoosh.Mailer.html
-config :phoenix_base, Phoenix.Mailer,
+config :phoenix_base, PhoenixBase.Mailer,
   adapter: Swoosh.Adapters.SMTP,
   relay: "smtp.example.com",
   username: {:system, "SMTP_USERNAME"},


### PR DESCRIPTION
- Added 'g' modifier to the regex given to `sed` so the replacement is applied globally, instead of only on the first match
- Calling `sed` through `xargs`. 

This fixes #16 
